### PR TITLE
Update splashing.js

### DIFF
--- a/kubejs/server_scripts/recipes/create/splashing.js
+++ b/kubejs/server_scripts/recipes/create/splashing.js
@@ -5,8 +5,8 @@ onEvent('recipes', (event) => {
             input: 'minecraft:andesite'
         },
         {
-            outputs: [Item.of('create:copper_nugget').chance(0.12), Item.of('create:limesand').chance(0.5)],
-            input: 'create:limestone'
+            outputs: [Item.of('create:copper_nugget').chance(0.12), Item.of('minecraft:clay_ball').chance(0.5)],
+            input: 'create:limesand'
         }
     ];
 


### PR DESCRIPTION
To fix #27 

Sand can be crushed into limesand already, and washing sand gives clay at 25%, so I think it makes sense for a "refined" sand to give clay at a higher rate.